### PR TITLE
update checksum for docker repos

### DIFF
--- a/vars/main/repos.yml
+++ b/vars/main/repos.yml
@@ -25,22 +25,22 @@ _docker_repos_download:
   all: []
   CentOS_7:
     - url: "https://download.docker.com/linux/centos/docker-ce.repo"
-      checksum: "sha256:6650718e0fe5202ae7618521f695d43a8bc051c539d7570f0edbfa5b4916f218"
+      checksum: "sha256:8ab5599eef0afcac10cbd3e8670873efee20fcceb5fb3526a62edeade603cec7"
       dest: "/etc/yum.repos.d/docker-ce.repo"
       gpgkey: "https://download.docker.com/linux/fedora/gpg"
   RedHat_7:
     - url: "https://download.docker.com/linux/centos/docker-ce.repo"
-      checksum: "sha256:6650718e0fe5202ae7618521f695d43a8bc051c539d7570f0edbfa5b4916f218"
+      checksum: "sha256:8ab5599eef0afcac10cbd3e8670873efee20fcceb5fb3526a62edeade603cec7"
       dest: "/etc/yum.repos.d/docker-ce.repo"
       gpgkey: "https://download.docker.com/linux/fedora/gpg"
   CentOS_8:
     - url: "https://download.docker.com/linux/centos/docker-ce.repo"
-      checksum: "sha256:6650718e0fe5202ae7618521f695d43a8bc051c539d7570f0edbfa5b4916f218"
+      checksum: "sha256:8ab5599eef0afcac10cbd3e8670873efee20fcceb5fb3526a62edeade603cec7"
       dest: "/etc/yum.repos.d/docker-ce.repo"
       gpgkey: "https://download.docker.com/linux/fedora/gpg"
   RedHat_8:
     - url: "https://download.docker.com/linux/centos/docker-ce.repo"
-      checksum: "sha256:6650718e0fe5202ae7618521f695d43a8bc051c539d7570f0edbfa5b4916f218"
+      checksum: "sha256:8ab5599eef0afcac10cbd3e8670873efee20fcceb5fb3526a62edeade603cec7"
       dest: "/etc/yum.repos.d/docker-ce.repo"
       gpgkey: "https://download.docker.com/linux/fedora/gpg"
   Fedora_31:


### PR DESCRIPTION
I've encountered an error when the roll starts to set up the docker repositories. It looks like the checksum has changed. Here's the error I get when I run the role at it's current state

```
TASK [crivetimihai.docker : repo file downloaded to /etc/yum.repos.d] ****************************
fatal: [host]: FAILED! => {"changed": false, "checksum_dest": "cccda062c436669011790aa0d4da2514c80db74f", "checksum_src": "cccda062c436669011790aa0d4da2514c80db74f", "dest": "/etc/yum.repos.d/docker-ce.repo", "elapsed": 0, "msg": "The checksum for /etc/yum.repos.d/docker-ce.repo did not match 6650718e0fe5202ae7618521f695d43a8bc051c539d7570f0edbfa5b4916f218; it was 8ab5599eef0afcac10cbd3e8670873efee20fcceb5fb3526a62edeade603cec7.", "src": "/home/user/.ansible/tmp/ansible-tmp-1612126304.2304296-149065733047380/tmpu5eC3J", "url": "https://download.docker.com/linux/centos/docker-ce.repo"}

```

And after update:

```
TASK [crivetimihai.docker : repo file downloaded to /etc/yum.repos.d] ****************************
changed: [host]
```

Reference I used for this fix: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1641